### PR TITLE
Updated README.md and exemplary task manifest

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -1,8 +1,0 @@
-# snap collector plugin - sessioninfo
-
-## Collected Metrics
-This plugin has the ability to gather the following metrics:
-
-Namespace | Description
-----------|-----------------------
-/pan/sessioninfo/num-active | session count.

--- a/README.md
+++ b/README.md
@@ -35,12 +35,17 @@ $ go get -u github.com/IrekRomaniuk/snap-plugin-collector-sessioninfo
 
 ### Collected Metrics
 
-List of collected metrics is described in [METRICS.md](https://github.com/IrekRomaniuk/snap-plugin-collector-sessioninfo/blob/master/METRICS.md).
+This plugin has the ability to gather the following metric:
+
+Namespace | Description
+----------|-----------------------
+/pan/sessioninfo/num-active | session count.
+
 
 ### Example
-Example running ping collector and writing data to a database.
+Example running sessioninfo collector and writing data to an Influx database.
 
-Load ping plugin
+Load sessioninfo plugin
 ```
 $ snaptel plugin load snap-plugin-collector-sessioninfo
 ```
@@ -71,24 +76,20 @@ workflow:
         api: ""
         ip: ""
         cmd: "&cmd=<show><session><info/></session></show>"
-    process:
+    publish:
       -
-        plugin_name: "passthru"
-        process: null
-        publish:
-          -
-            plugin_name: "influxdb"
-            config:
-              host: "localhost"
-              port: 8086
-              database: "test"
-              retention: "default"
-              user: "admin"
-              password: "admin"
-              https: false
-              skip-verify: false
+        plugin_name: "influxdb"
+        config:
+          host: "localhost"
+          port: 8086
+          database: "test"
+          retention: "default"
+          user: "admin"
+          password: "admin"
+          https: false
+          skip-verify: false
 ```
-Load file plugin for publishing:
+Load influxdb plugin for publishing:
 ```
 $ snaptel plugin load snap-plugin-publisher-influxdb
 ```

--- a/examples/task.yml
+++ b/examples/task.yml
@@ -12,19 +12,15 @@ workflow:
         api: ""
         ip: ""
         cmd: "&cmd=<show><session><info/></session></show>"
-    process:
+    publish:
       -
-        plugin_name: "passthru"
-        process: null
-        publish:
-          -
-            plugin_name: "influxdb"
-            config:
-              host: "localhost"
-              port: 8086
-              database: "test"
-              retention: "default"
-              user: "admin"
-              password: "admin"
-              https: false
-              skip-verify: false
+        plugin_name: "influxdb"
+        config:
+          host: "localhost"
+          port: 8086
+          database: "test"
+          retention: "default"
+          user: "admin"
+          password: "admin"
+          https: false
+          skip-verify: false


### PR DESCRIPTION
## Summary of changes:
- based on this plugin exposes one metric, this one has been moved from METRICS.md to README.md
- in README.md#example:
    - changed `Load file plugin for publishing:` to `Load influxdb plugin for publishing:` to keep consistency with an exemplary task manifest
    - removed passthru-processor from the task manifest

cc: @irom77 
